### PR TITLE
Add references for Doppler CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,5 @@ crashlytics-build.properties
 fabric.properties
 
 todo.txt
+
+.vscode

--- a/hecksum/references.py
+++ b/hecksum/references.py
@@ -100,32 +100,134 @@ class Doppler(ReferenceFactory):
 
 
 codecov_bash_uploader = CodecovBashUploader()
+
 test_failure = ReferenceFactory(
     download_url=cast(HttpUrl, 'https://hecksum.com/failure.txt'),
     checksum_url=cast(HttpUrl, 'https://hecksum.com/failureSHA512.txt'),
     algorithm='sha512'
 )
+
+############
+# Transmission Reference Definitions
+############
+
 transmission_mac = Transmission(
     file_name_template='Transmission-{version}.dmg',
     sha_key='sha256_dmg',
     version_key='current_version_dmg'
 )
+
 transmission_win_32 = Transmission(
     file_name_template='transmission-{version}-x86.msi',
     sha_key='sha256_msi32',
     version_key='current_version_msi',
 )
+
 transmission_win_64 = Transmission(
     file_name_template='transmission-{version}-x64.msi',
     sha_key='sha256_msi64',
     version_key='current_version_msi',
 )
+
 transmission_linux = Transmission(
     file_name_template='transmission-{version}.tar.xz',
     sha_key='sha256_tar',
     version_key='current_version_tar',
 )
 
-doppler_windows_armv7 = Doppler(
+
+############
+# Doppler Reference Definitions
+############
+
+doppler_linux_amd64 = Doppler(
+    architecture='linux_amd64'
+)
+
+doppler_linux_i386 = Doppler(
+    architecture='linux_i386'
+)
+
+doppler_linux_armv7 = Doppler(
+    architecture='linux_armv7'
+)
+
+doppler_openbsd_arm64 = Doppler(
+    architecture='openbsd_arm64'
+)
+
+doppler_linux_armv6 = Doppler(
+    architecture='linux_armv6'
+)
+
+doppler_openbsd_armv6 = Doppler(
+    architecture='openbsd_armv6'
+)
+
+doppler_macOS_amd64 = Doppler(
+    architecture='macOS_amd64'
+)
+
+doppler_macOS_arm64 = Doppler(
+    architecture='macOS_arm64'
+)
+
+doppler_freebsd_armv7 = Doppler(
+    architecture='freebsd_armv7'
+)
+
+doppler_openbsd_amd64 = Doppler(
+    architecture='openbsd_amd64'
+)
+
+doppler_openbsd_i386 = Doppler(
+    architecture='openbsd_i386'
+)
+
+doppler_linux_arm64 = Doppler(
     architecture='linux_arm64'
+)
+
+doppler_openbsd_armv7 = Doppler(
+    architecture='openbsd_armv7'
+)
+
+doppler_freebsd_amd64 = Doppler(
+    architecture='freebsd_amd64'
+)
+
+doppler_netbsd_amd64 = Doppler(
+    architecture='netbsd_amd64'
+)
+
+doppler_windows_amd64 = Doppler(
+    architecture='windows_amd64'
+)
+
+doppler_netbsd_armv7 = Doppler(
+    architecture='netbsd_armv7'
+)
+
+doppler_freebsd_arm64 = Doppler(
+    architecture='freebsd_arm64'
+)
+
+doppler_netbsd_i386 = Doppler(
+    architecture='netbsd_i386'
+)
+
+doppler_netbsd_armv6 = Doppler(
+    architecture='netbsd_armv6'
+)
+
+doppler_freebsd_armv6 = Doppler(
+    architecture='freebsd_armv6'
+)
+
+doppler_windows_armv7 = Doppler(
+    architecture='windows_armv7'
+)
+
+doppler_windows_armv6 = Doppler(
+    architecture='windows_armv6'
 )

--- a/hecksum/references.py
+++ b/hecksum/references.py
@@ -86,7 +86,8 @@ class Doppler(ReferenceFactory):
     architecture: str
 
     # TODO: Doppler releases in multiple formats per architecture. This doesn't handle that and
-    # only retrieves the first file for a particular architecture.
+    # only retrieves the first file for a particular architecture. We should find a way to support
+    # all the releases in whichever format.
     def _populate(self, ref: Reference) -> None:
         latest_release_url = requests.get('https://github.com/DopplerHQ/cli/releases/latest').url
         version = re.search(r'\d+\.\d+\.\d+', latest_release_url)[0]


### PR DESCRIPTION
Hey Travis, I decided to give adding a project a shot. I added the [Doppler CLI](https://github.com/DopplerHQ/cli/tree/3.24.1) which is used to manage secrets. It seemed like a worthwhile time to do this especially for tools which pose a big security threat if they're compromised. Overall it was pretty easy although I ran into some issues regarding the way Doppler does their releases, you can see the checksum file here: https://github.com/DopplerHQ/cli/releases/download/3.24.1/checksums.txt

The file has multiple listing for the same release in different architectures, and the same architecture will have the multiple formats too. What I decided to do was specify an architecture and each reference then verifies for a particular architecture, selecting the first release it finds in the checksum file. I think for this to scale a little better we need a way to have multiple releases either per Project (So that check() checks each release) or each Reference contains multiple releases. I haven't put too much thought into this though, kind of wanted to see what you think of this PR/that multiple release idea.

Anyways, let me know what you think!